### PR TITLE
Lock some stuff behind `#if [condition]`

### DIFF
--- a/polymod/hscript/_internal/PolymodClassDeclEx.hx
+++ b/polymod/hscript/_internal/PolymodClassDeclEx.hx
@@ -1,5 +1,6 @@
 package polymod.hscript._internal;
 
+#if hscript
 import hscript.Expr.ClassDecl;
 import hscript.Expr.FieldDecl;
 import polymod.hscript._internal.PolymodScriptClass;
@@ -30,4 +31,4 @@ typedef PolymodClassImport = {
 	@:optional var cls:Class<Dynamic>;
 	@:optional var enm:Enum<Dynamic>;
 }
-
+#end

--- a/polymod/hscript/_internal/PolymodExprEx.hx
+++ b/polymod/hscript/_internal/PolymodExprEx.hx
@@ -1,5 +1,6 @@
 package polymod.hscript._internal;
 
+#if hscript
 #if hscriptPos
 class ErrorEx
 {
@@ -132,3 +133,4 @@ ECustom(msg:String);
 		throw "Unimplemented error type " + err;
 	}
 }
+#end

--- a/polymod/hscript/_internal/PolymodPrinterEx.hx
+++ b/polymod/hscript/_internal/PolymodPrinterEx.hx
@@ -1,5 +1,6 @@
 package polymod.hscript._internal;
 
+#if hscript
 import hscript.Printer;
 
 class PolymodPrinterEx extends Printer
@@ -37,3 +38,4 @@ class PolymodPrinterEx extends Printer
 		#end
 	}
 }
+#end

--- a/polymod/hscript/_internal/PolymodScriptClass.hx
+++ b/polymod/hscript/_internal/PolymodScriptClass.hx
@@ -1,5 +1,6 @@
 package polymod.hscript._internal;
 
+#if hscript
 import hscript.Expr;
 import polymod.hscript._internal.PolymodExprEx;
 
@@ -558,3 +559,4 @@ class PolymodScriptClass
 	}
 	#end
 }
+#end

--- a/polymod/hscript/_internal/PolymodScriptMacro.hx
+++ b/polymod/hscript/_internal/PolymodScriptMacro.hx
@@ -1,5 +1,6 @@
 package polymod.hscript._internal;
 
+#if hscript
 import EReg;
 import haxe.macro.Context;
 import haxe.macro.Expr;
@@ -84,10 +85,6 @@ class PolymodScriptMacro
 	static var scriptOverrides:Array<Expr> = [];
 	public static function buildScriptImpls(?filters:Array<String>):Void
 	{
-		#if !hscript
-		return;
-		#end
-
 		// if no filters are given
 		// create a scripted implementation
 		// for every class
@@ -588,3 +585,4 @@ class PolymodScriptMacro
 		return scriptOverrides;
 	}
 }
+#end

--- a/polymod/hscript/_internal/PolymodScriptManager.hx
+++ b/polymod/hscript/_internal/PolymodScriptManager.hx
@@ -1,5 +1,6 @@
 package polymod.hscript._internal;
 
+#if hscript
 import hscript.Expr;
 import polymod.hscript._internal.PolymodClassDeclEx;
 
@@ -102,6 +103,7 @@ class PolymodScriptManager
 		}
 	}
 
+	#if lime
 	public function registerScriptClassByPathAsync(path:String):lime.app.Future<Bool>
 	{
 		var promise = new lime.app.Promise<Bool>();
@@ -154,6 +156,7 @@ class PolymodScriptManager
 		// Await the promise
 		return promise.future;
 	}
+	#end
 
 	public function validateImports():Void
 	{
@@ -548,3 +551,4 @@ class PolymodScriptManager
 	}
 	#end
 }
+#end


### PR DESCRIPTION
Imo I think this should be locked behind a `#if lime` cuz lime's not a required dependency for polymod lol
the same principle applies to most of the classes inside `hscript/_internal` folder since hscript is not a required dependency

![image](https://github.com/user-attachments/assets/f9832d51-2cd2-4776-ac81-63d5cd4a639e)

for ur [pr](https://github.com/larsiusprime/polymod/pull/201)
also if you think some of my polymod prs (like the support for get and set functions) would be fitting inside yours lemme know